### PR TITLE
Expand CoC Scope to include Discord

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,9 +52,11 @@ decisions when appropriate.
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+Examples of representing our community include: 
+* Using an official e-mail address
+* Posting via an official social media account 
+* Performing moderation within public voice, video, and text chat apps
+* Acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 


### PR DESCRIPTION
Within the Scope section, update the example section to include "performing moderation within public voice, video, and text chat apps."

This will expand the scope to include our Discord. 

Added bullets for better visibility.