### PR TITLE
added num captures to recordingslist

### DIFF
--- a/src/Components/RecordingsBrowser/Directory.js
+++ b/src/Components/RecordingsBrowser/Directory.js
@@ -59,7 +59,6 @@ const Directory = ({
             <td></td>
             <td></td>
             <td></td>
-            <td></td>
           </tr>
         )}
         {item.children.map((item) => (

--- a/src/Components/RecordingsBrowser/File.js
+++ b/src/Components/RecordingsBrowser/File.js
@@ -119,10 +119,9 @@ export default function FileRow({
       <td className="align-middle">{item.sampleRate} MHz</td>
       <td className="align-middle">
         <div>
-          <Button type="button" variant="secondary" onClick={toggle}>
+          <Button type="button" variant="secondary" style={{ marginBottom: '7px' }} onClick={toggle}>
             {item.numberOfAnnotation}
           </Button>
-
           <Modal isOpen={modal} toggle={toggle} size="lg">
             <ModalHeader toggle={toggle}>{item.name}</ModalHeader>
             <ModalBody>
@@ -141,10 +140,14 @@ export default function FileRow({
               </table>
             </ModalBody>
           </Modal>
+          <br></br>({item.numberOfCaptures} Capture{item.numberOfCaptures > 1 && 's'})
         </div>
       </td>
-      <td className="align-middle">{item.author}</td>
-      <td className="align-middle">{item.email}</td>
+      <td className="align-middle">
+        {item.author}
+        <br></br>
+        {item.email}
+      </td>
     </tr>
   );
 }

--- a/src/Components/RecordingsBrowser/RecordingsBrowser.js
+++ b/src/Components/RecordingsBrowser/RecordingsBrowser.js
@@ -192,7 +192,6 @@ export default function RecordingsBrowser(props) {
               <th>Sample Rate</th>
               <th>Number of Annotations</th>
               <th style={{ width: '10%' }}>Author</th>
-              <th style={{ width: '10%' }}>Email</th>
             </tr>
           </thead>
           <tbody>

--- a/src/Utils/parseMeta.js
+++ b/src/Utils/parseMeta.js
@@ -48,6 +48,7 @@ export default function parseMeta(json_string, baseUrl, fName, metaFileHandle, d
     frequency: (obj['captures'][0]['core:frequency'] ?? 1e6) / 1e6, // in MHz
     annotations: obj['annotations'],
     numberOfAnnotation: obj['annotations'].length,
+    numberOfCaptures: obj['captures'].length,
     author: author,
     email: email,
     type: 'file',


### PR DESCRIPTION
the way more than one collection shows up on the spectrogram page is still up for debate, e.g. whether it should be a separate dropdown to select which collection is being shown (since they can have different center freqs) or whatnot