### PR TITLE
Add datasource api methods

### DIFF
--- a/client/src/api/datasource/ApiClient.ts
+++ b/client/src/api/datasource/ApiClient.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import { DataSourceClient } from './DataSourceClient';
+
+export class ApiClient implements DataSourceClient {
+  list() {
+    return axios.get('/api/datasources');
+  }
+  get(dataSource: string) {
+    return axios.get(`/api/datasources/${dataSource}`);
+  }
+  get_meta(dataSource: string, filePath: string) {
+    return axios.get(`/api/datasources/${dataSource}/${filePath}/meta`);
+  }
+  get_datasource_meta(dataSource: string): Promise<any> {
+    return axios.get(`/api/datasources/${dataSource}/meta`);
+  }
+  update_meta(dataSource: string, filePath: string, meta: object) {
+    return axios.put(`/api/datasources/${dataSource}/${filePath}/meta`, meta);
+  }
+  features() {
+    return {
+      save_files: true,
+    };
+  }
+}

--- a/client/src/api/datasource/BlobClient.ts
+++ b/client/src/api/datasource/BlobClient.ts
@@ -1,0 +1,24 @@
+import { DataSourceClient } from './DataSourceClient';
+
+export class BlobClient implements DataSourceClient {
+  get_datasource_meta(dataSource: string): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+  update_meta(dataSource: string, filePath: string, meta: object): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+  list(): Promise<any> {
+    throw new Error('Not implemented');
+  }
+  get(dataSource: string): Promise<any> {
+    throw new Error('Not implemented');
+  }
+  get_meta(dataSource: string, filePath: string): Promise<any> {
+    throw new Error('Not implemented');
+  }
+  features() {
+    return {
+      update_meta: false,
+    };
+  }
+}

--- a/client/src/api/datasource/DataSourceClient.ts
+++ b/client/src/api/datasource/DataSourceClient.ts
@@ -1,0 +1,12 @@
+export interface DataSourceClient {
+  list(): Promise<any>;
+  get(dataSource: string): Promise<any>;
+  get_meta(dataSource: string, filePath: string): Promise<any>;
+  get_datasource_meta(dataSource: string): Promise<any>;
+  update_meta(dataSource: string, filePath: string, meta: object): Promise<any>;
+  features(): object;
+}
+
+export const CLIENT_TYPE_API = 'api';
+export const CLIENT_TYPE_LOCAL = 'local';
+export const CLIENT_TYPE_BLOB = 'azure_blob';

--- a/client/src/api/datasource/DataSourceClientFactory.ts
+++ b/client/src/api/datasource/DataSourceClientFactory.ts
@@ -1,0 +1,17 @@
+import { LocalClient } from './LocalClient';
+import { ApiClient } from './ApiClient';
+import { BlobClient } from './BlobClient';
+import { CLIENT_TYPE_API, CLIENT_TYPE_BLOB, CLIENT_TYPE_LOCAL, DataSourceClient } from './DataSourceClient';
+
+export const DataSourceClientFactory = (type: string): DataSourceClient => {
+  switch (type) {
+    case CLIENT_TYPE_API:
+      return new ApiClient();
+    case CLIENT_TYPE_LOCAL:
+      return new LocalClient();
+    case CLIENT_TYPE_BLOB:
+      return new BlobClient();
+    default:
+      throw new Error(`Unknown data source type: ${type}`);
+  }
+};

--- a/client/src/api/datasource/LocalClient.ts
+++ b/client/src/api/datasource/LocalClient.ts
@@ -1,0 +1,24 @@
+import { DataSourceClient } from './DataSourceClient';
+
+export class LocalClient implements DataSourceClient {
+  get_datasource_meta(dataSource: string): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+  update_meta(dataSource: string, filePath: string, meta: object): Promise<any> {
+    throw new Error('Method not implemented.');
+  }
+  list(): Promise<any> {
+    throw new Error('Not implemented');
+  }
+  get(dataSource: string): Promise<any> {
+    throw new Error('Not implemented');
+  }
+  get_meta(dataSource: string, filePath: string): Promise<any> {
+    throw new Error('Not implemented');
+  }
+  features() {
+    return {
+      update_meta: false,
+    };
+  }
+}

--- a/client/src/api/datasource/Queries.ts
+++ b/client/src/api/datasource/Queries.ts
@@ -1,0 +1,57 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { DataSourceClientFactory } from './DataSourceClientFactory';
+
+const fetchMeta = async (type, dataSource, filePath) => {
+  const client = DataSourceClientFactory(type);
+  const response = await client.get_meta(dataSource, filePath);
+  return response.data;
+};
+
+const fetchDataSources = async (type) => {
+  const client = DataSourceClientFactory(type);
+  const response = await client.list();
+  return response;
+};
+
+const fetchDataSource = async (type, dataSourceID) => {
+  const client = DataSourceClientFactory(type);
+  const response = await client.get(dataSourceID);
+  return response;
+};
+
+const fetchDataSourceMeta = async (type, dataSourceID) => {
+  const client = DataSourceClientFactory(type);
+  const response = await client.get_datasource_meta(dataSourceID);
+  return response;
+};
+
+export const CLIENT_TYPE_API = 'api';
+export const CLIENT_TYPE_LOCAL = 'local';
+export const CLIENT_TYPE_BLOB = 'blob';
+
+const updateDataSourceMeta = async (type, dataSourceID, filePath, meta) => {
+  const client = DataSourceClientFactory(type);
+  const response = await client.update_meta(dataSourceID, filePath, meta);
+  return response;
+};
+
+export const getDataSources = (type) => useQuery(['datasource', type], (type) => fetchDataSources(type));
+export const getDataSource = (type: string, dataSourceID: string) =>
+  useQuery(['datasource', type, dataSourceID], () => fetchDataSource(type, dataSourceID));
+export const getDataSourceMeta = (type: string, dataSourceID: string) =>
+  useQuery(['datasource', type, dataSourceID, 'meta'], () => fetchDataSourceMeta(type, dataSourceID));
+export const getMeta = (type: string, dataSourceID: string, filePath: string) =>
+  useQuery(['datasource', type, dataSourceID, filePath, 'meta'], () => fetchMeta(type, dataSourceID, filePath));
+export const updateMeta = (type: string, dataSourceID: string, filePath: string, meta: object) =>
+  useMutation({
+    mutationFn: () => updateDataSourceMeta(type, dataSourceID, filePath, meta),
+    onSettled(data, error, variables, context) {
+      let client = useQueryClient();
+      client.invalidateQueries(['datasource', type, dataSourceID]);
+    },
+  });
+
+export const getFeatures = (type: string) => {
+  const client = DataSourceClientFactory(type);
+  return client.features();
+};


### PR DESCRIPTION
### What does this PR do?

This PR adds the stub for the calls to the backend api.

This implements it in a way that is transparent to the rest of the application if the data it is comming from each one of the iomplementations. This stub methods are here just to enable us to colaborate in the implementation of such methods.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [x] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc

