### PR TITLE
Fix timing auto size bug

### DIFF
--- a/client/src/Components/AutoSizeInput/AutoSizeInput.tsx
+++ b/client/src/Components/AutoSizeInput/AutoSizeInput.tsx
@@ -24,7 +24,7 @@ export const AutoSizeInput = ({
 
   useEffect(() => {
     setWidth(span.current.offsetWidth + 3);
-  }, [content]);
+  }, [span.current?.offsetWidth]);
 
   const changeHandler = useCallback((evt) => {
     setContent(evt.target.value);


### PR DESCRIPTION
### What does this PR do?
Odd async issue where the offsetWidth wasn't being set on first auto-size input item when content changed, changed to offsetWidth as a dependency so it only changes once it has definitely been updated.

Before:
![image](https://github.com/IQEngine/IQEngine/assets/9397730/1b2e9e11-bdd0-43d7-b79b-2b3452fb8979)

After:
![image](https://github.com/IQEngine/IQEngine/assets/9397730/11bf6df5-0e64-4adc-adca-ab32a2d88302)


### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you successfully ran tests with your changes locally? Including container validation.
* [X] Have you lint your code locally prior to submission?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [X] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc
