### PR TITLE
Global Properties moved to below annotations, with modifications

### DIFF
--- a/client/src/Components/AutoSizeInput/AutoSizeInput.tsx
+++ b/client/src/Components/AutoSizeInput/AutoSizeInput.tsx
@@ -59,7 +59,7 @@ export const AutoSizeInput = ({
           type={type ?? 'text'}
           title={content}
           value={content}
-          className={`bg-base-100 input no-spin ${className}`}
+          className={`bg-base-100 input input-autosize no-spin ${className}`}
           style={{ width }}
           autoFocus
           onChange={changeHandler}

--- a/client/src/Components/DataTable/DataTable.tsx
+++ b/client/src/Components/DataTable/DataTable.tsx
@@ -97,7 +97,7 @@ export const DataTable = ({ dataColumns, dataRows }: TableProps) => {
         </div>
         <div>
           <input
-            className={`bg-base-100 input no-spin`}
+            className={`bg-base-100 input input-autosize no-spin`}
             aria-label="filter"
             value={filterInput}
             onChange={(e) => {

--- a/client/src/Components/GlobalProperties/GlobalProperties.tsx
+++ b/client/src/Components/GlobalProperties/GlobalProperties.tsx
@@ -1,0 +1,89 @@
+import React, { ReactElement } from 'react';
+import { SigMFMetadata } from '@/Utils/sigmfMetadata';
+import { SpectrogramContext } from '@/Components/Spectrogram/SpectrogramContext';
+
+export interface GlobalPropertiesProps {
+  meta: SigMFMetadata;
+  setMeta: (meta: SigMFMetadata) => void;
+}
+
+export const  GlobalProperties = ({ meta, setMeta }) => {
+  if(!meta) return <></>
+
+  const globalMeta = meta.global ?? {};
+  
+  const titleCase = (str: string) : string => {
+    str = str.replace('core:', '').replace(':', ' ').replace('_', ' ').replace('hw', 'Hardware');
+    let strArr: string[] = str.toLowerCase().split(' ');
+    for (var i = 0; i < strArr.length; i++) {
+      strArr[i] = strArr[i].charAt(0).toUpperCase() + strArr[i].slice(1);
+    }
+    return strArr.join(' ');
+  }
+
+  const stringifyObject = (key: string, value: any) : string => {
+    if(typeof value === "object" && value !== null) {
+      return JSON.stringify(value, undefined, 4);
+    }
+    return value
+  }
+
+  const renderFormInput = (key: string, value: any) : ReactElement<P> => {
+    if(key.indexOf('core:description') !== -1 || 
+      (typeof value === "object" && value !== null) )
+      return (
+        <textarea
+          name={key}
+          placeholder={value} 
+          className="textarea pl-4 pr-4 textarea-bordered textarea-success textarea-lg w-full"
+          data-testid={key}
+          defaultValue={stringifyObject(key, value)}
+          onChange={(event) => handleChange(event, key)}
+        />
+      )
+    return (
+      <input
+          name={key}
+          type="text" 
+          placeholder={value} 
+          className="input input-bordered input-success w-full"
+          data-testid={key}
+          defaultValue={stringifyObject(key, value)}
+          onChange={(event) => handleChange(event, key)}
+        />
+    )
+  }
+  const handleChange = (e, key: string) : null => {
+    const { value } = e.target;
+    setMeta(Object.assign(new SigMFMetadata(), {
+      ...meta,
+      global: {
+        ...globalMeta,
+        [key]: value
+      }
+    }));
+  }
+
+  return (
+    <div className="pr-4">
+      {meta && (
+        <div key={'InfoPane'}>
+          {Object.entries(globalMeta).map(([key, value]) => (
+            <div className="mb-3" key={key}>
+              <div className="mb-3">
+                <div className="form-control w-full ml-2">
+                  <label className="label">
+                    <span className="label-text">{titleCase(key)}</span>
+                  </label>
+                  {renderFormInput(key, value)}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default GlobalProperties;

--- a/client/src/Components/GlobalProperties/GlobalProperties.tsx
+++ b/client/src/Components/GlobalProperties/GlobalProperties.tsx
@@ -11,7 +11,7 @@ export const  GlobalProperties = ({ meta, setMeta }) => {
   if(!meta) return <></>
 
   const globalMeta = meta.global ?? {};
-  
+
   const titleCase = (str: string) : string => {
     str = str.replace('core:', '').replace(':', ' ').replace('_', ' ').replace('hw', 'Hardware');
     let strArr: string[] = str.toLowerCase().split(' ');
@@ -29,12 +29,12 @@ export const  GlobalProperties = ({ meta, setMeta }) => {
   }
 
   const renderFormInput = (key: string, value: any) : ReactElement<P> => {
-    if(key.indexOf('core:description') !== -1 || 
+    if(key.indexOf('core:description') !== -1 ||
       (typeof value === "object" && value !== null) )
       return (
         <textarea
           name={key}
-          placeholder={value} 
+          placeholder={value}
           className="textarea pl-4 pr-4 textarea-bordered textarea-success textarea-lg w-full"
           data-testid={key}
           defaultValue={stringifyObject(key, value)}
@@ -44,8 +44,8 @@ export const  GlobalProperties = ({ meta, setMeta }) => {
     return (
       <input
           name={key}
-          type="text" 
-          placeholder={value} 
+          type="text"
+          placeholder={value}
           className="input input-bordered input-success w-full"
           data-testid={key}
           defaultValue={stringifyObject(key, value)}

--- a/client/src/Components/GlobalProperties/__tests__/GlobalProperties.test.tsx
+++ b/client/src/Components/GlobalProperties/__tests__/GlobalProperties.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { SigMFMetadata } from '@/Utils/sigmfMetadata';
+import { GlobalProperties, GlobalPropertiesProps } from '../GlobalProperties';
+
+describe('GlobalProperties component', () => {
+    const meta = Object.assign(new SigMFMetadata(), JSON.parse(JSON.stringify({
+        global: {
+            'core:datatype': 'datatype test',
+            'core:version': 'version test',
+            'core:offset': 0,
+            'core:sample_rate': 1,
+            'core:description': 'lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+            'traceability:origin': {"type": "traceability test"},
+            'traceability:sample_length': 100
+
+        }
+    })));
+    const setMeta = vi.fn();
+    test('Renders correctly', async () => {
+        render(<GlobalProperties meta={meta} setMeta={setMeta}/>);
+        expect(screen.getByTestId('core:datatype').value).toBe('datatype test');
+        expect(screen.getByTestId('core:version').value).toBe('version test');
+        expect(screen.getByTestId('core:offset').value).toBe('0');
+        expect(screen.getByTestId('core:sample_rate').value).toBe('1');
+        expect(screen.getByTestId('core:description').value).toBe('lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.');
+        expect(screen.getByText(/"type": "traceability test"/));
+        expect(screen.getByTestId('traceability:sample_length').value).toBe('100');
+    });
+    test('setMeta is fired on value change', async () => {
+      render(<GlobalProperties meta={meta} setMeta={setMeta}/>);
+      const datatype = screen.getByTestId('core:datatype');
+      await userEvent.type(datatype, '1');
+      expect(datatype.value).toBe('datatype test1');
+      expect(setMeta).toHaveBeenCalledTimes(1);
+      expect(setMeta).toHaveBeenCalledWith({
+        ...meta,
+        global: {
+          ...meta.global,
+          'core:datatype': 'datatype test1'
+        }
+      })
+    });
+});

--- a/client/src/Components/Spectrogram/Sidebar.tsx
+++ b/client/src/Components/Spectrogram/Sidebar.tsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import SettingsPane from './SettingsPane';
 import { DetectorPane } from './DetectorPane';
-// import InfoPane from './InfoPane';
 import { SigMFMetadata } from '@/Utils/sigmfMetadata';
 
 export interface SidebarProps {
@@ -75,15 +74,6 @@ const Sidebar = (props) => {
           />
         </div>
       </details>
-
-      {/* <details>
-        <summary className="pl-2 mt-2 bg-primary outline outline-1 outline-primary text-lg text-base-100 hover:bg-green-800">
-          Global Properties
-        </summary>
-        <div className="outline outline-1 outline-primary p-2">
-          <InfoPane />
-        </div>
-      </details> */}
     </div>
   );
 };

--- a/client/src/Components/Spectrogram/Sidebar.tsx
+++ b/client/src/Components/Spectrogram/Sidebar.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import SettingsPane from './SettingsPane';
 import { DetectorPane } from './DetectorPane';
-import InfoPane from './InfoPane';
+// import InfoPane from './InfoPane';
 import { SigMFMetadata } from '@/Utils/sigmfMetadata';
 
 export interface SidebarProps {
@@ -76,14 +76,14 @@ const Sidebar = (props) => {
         </div>
       </details>
 
-      <details>
+      {/* <details>
         <summary className="pl-2 mt-2 bg-primary outline outline-1 outline-primary text-lg text-base-100 hover:bg-green-800">
           Global Properties
         </summary>
         <div className="outline outline-1 outline-primary p-2">
           <InfoPane />
         </div>
-      </details>
+      </details> */}
     </div>
   );
 };

--- a/client/src/Components/Spectrogram/SpectrogramPage.tsx
+++ b/client/src/Components/Spectrogram/SpectrogramPage.tsx
@@ -16,6 +16,7 @@ import { INITIAL_PYTHON_SNIPPET, TILE_SIZE_IN_IQ_SAMPLES } from '../../Utils/con
 import TimeSelector from './TimeSelector';
 import { ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import AnnotationList from '@/Components/Annotation/AnnotationList';
+import { GlobalProperties } from '@/Components/GlobalProperties/GlobalProperties';
 import { MetaViewer } from '@/Components/MetaViewer/MetaViewer';
 import { SpectrogramContext } from './SpectrogramContext';
 import { useParams } from 'react-router-dom';
@@ -538,6 +539,18 @@ export const SpectrogramPage = () => {
                 meta={meta}
                 setHandleTop={setHandleTop}
                 spectrogramHeight={spectrogramHeight}
+                setMeta={setMeta}
+              />
+            </div>
+          </details>
+
+          <details>
+            <summary className="pl-2 mt-2 bg-primary outline outline-1 outline-primary text-lg text-base-100 hover:bg-green-800">
+              Global Properties
+            </summary>
+            <div className="outline outline-1 outline-primary p-2">
+              <GlobalProperties
+                meta={meta}
                 setMeta={setMeta}
               />
             </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -44,7 +44,7 @@ div.datatypetext {
   white-space: pre;
 }
 
-.input {
+.input-autosize {
   min-width: 1px;
   padding: 0;
   max-width: 250px;


### PR DESCRIPTION
### What does this PR do?

moved the global properties view from the sidebar, to below the annotations view.
correctly shows json objects
changes to state balloon out and modify the meta object via the setMeta function on any state change to the global object



### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [x] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?

