### PR TITLE
added docker-compose for iqengine, plugins and mongodb containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.2"
+
+services:
+  iqengine:
+    image: ghcr.io/iqengine/iqengine:latest
+    environment:
+      PLUGINS_ENDPOINT: plugins:8000
+      METADATA_DB_CONNECTION_STRING: mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@mongo:27017
+    depends_on:
+      - mongo
+    ports:
+      - 3000:3000
+  plugins:
+    image: ghcr.io/iqengine/plugins:latest
+    depends_on:
+      - mongo
+    ports:
+      - 8000:8000
+  mongo:
+    image: mongo:4.2
+    restart: always
+    volumes:
+      - ${MONGO_DATASOURCE}:/data/db
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}


### PR DESCRIPTION
### What does this PR do?

added docker-compose for the iqengine, plugins & mongod services.
all ports are exposed, in case local access is required (rather then exec'ing into a container etc etc), outside of the docker network 
for plugins, it's dependent on the image being published first

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [x] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?

