### PR TITLE
Fix plugin requiring parameters to run

### DIFF
--- a/client/src/pages/spectrogram/components/PluginsPane.tsx
+++ b/client/src/pages/spectrogram/components/PluginsPane.tsx
@@ -215,19 +215,22 @@ export const PluginsPane = ({ cursorsEnabled, handleProcessTime, meta, setMeta }
       <label className="label">
         Plugin:
         <select className="rounded bg-base-content text-base-100" value={selectedPlugin} onChange={handleChangePlugin}>
-          <option disabled selected value="">
+          <option disabled value="">
             Select a Plugin
           </option>
           {plugins && !isError && plugins?.map((plugin) => <PluginOption plugin={plugin} />)})
         </select>
       </label>
       {selectedPlugin && (
-        <EditPluginParameters
-          pluginUrl={selectedPlugin}
-          handleSubmit={handleSubmit}
-          setPluginParameters={setPluginParameters}
-          pluginParameters={pluginParameters}
-        />
+        <>
+          <EditPluginParameters
+            pluginUrl={selectedPlugin}
+            handleSubmit={handleSubmit}
+            setPluginParameters={setPluginParameters}
+            pluginParameters={pluginParameters}
+          />
+          <button onClick={handleSubmit}>Run Plugin</button>
+        </>
       )}
 
       {modalOpen && (

--- a/client/src/pages/spectrogram/hooks/useGetPluginsComponents.tsx
+++ b/client/src/pages/spectrogram/hooks/useGetPluginsComponents.tsx
@@ -24,12 +24,7 @@ interface PluginParametersProps {
   pluginParameters: PluginParameters;
 }
 
-export function EditPluginParameters({
-  pluginUrl,
-  handleSubmit,
-  setPluginParameters,
-  pluginParameters,
-}: PluginParametersProps) {
+export function EditPluginParameters({ pluginUrl, setPluginParameters, pluginParameters }: PluginParametersProps) {
   const { data: parameters } = useGetPluginParameters(pluginUrl);
   useEffect(() => {
     console.log('parameters', parameters);
@@ -75,7 +70,6 @@ export function EditPluginParameters({
               </div>
             ))}
           </div>
-          <button onClick={handleSubmit}>Run Plugin</button>
         </>
       )}
     </>

--- a/plugins/src/wav_out/wav_out.py
+++ b/plugins/src/wav_out/wav_out.py
@@ -22,12 +22,6 @@ class Plugin:
     sample_rate: int = 0
     center_freq: int = 0
 
-    # custom params - these are returned if you GET /plugins/plugin-name
-    #
-    numtaps: int = 51
-    # cutoff: float = 1e6  # relative to sample rate
-    # width: float = 0.1e6  # relative to sample rate
-
     def run(self, samples):
         file_path = path.dirname(path.realpath(__file__))
         with open(f"{file_path}/sheep.wav", mode="rb") as wavfile:


### PR DESCRIPTION
### What does this PR do?

Fix the need forr the pluging to have a parameter to run

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [x] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc
