### PR TITLE
Change api query return type

### DIFF
--- a/api/tests/test_data.py
+++ b/api/tests/test_data.py
@@ -60,8 +60,8 @@ valid_metadata_array = [
                 "type": "api",
                 "account": "test_account",
                 "container": "test_container",
-                "file_path": "test_file_path"
-        },
+                "file_path": "test_file_path",
+            },
             "traceability:revision": None,
         },
         "captures": [

--- a/api/tests/test_data.py
+++ b/api/tests/test_data.py
@@ -56,7 +56,12 @@ valid_metadata_array = [
             "core:sha512": None,
             "core:trailing_bytes": None,
             "core:version": "0.0.1",
-            "traceability:origin": None,
+            "traceability:origin" : {
+                "type" : "api",
+                "account" : "test_account",
+                "container" : "test_container",
+                "file_path" : "test_file_path"
+		},
             "traceability:revision": None,
         },
         "captures": [
@@ -80,5 +85,14 @@ valid_metadata_array = [
                 "core:uuid": None,
             }
         ],
+    }
+]
+
+valid_datasourcereference_array = [
+    {
+        "type": "api",
+        "account": "test_account",
+        "container": "test_container",
+        "file_path": "test_file_path",
     }
 ]

--- a/api/tests/test_data.py
+++ b/api/tests/test_data.py
@@ -56,12 +56,12 @@ valid_metadata_array = [
             "core:sha512": None,
             "core:trailing_bytes": None,
             "core:version": "0.0.1",
-            "traceability:origin" : {
-                "type" : "api",
-                "account" : "test_account",
-                "container" : "test_container",
-                "file_path" : "test_file_path"
-		},
+            "traceability:origin": {
+                "type": "api",
+                "account": "test_account",
+                "container": "test_container",
+                "file_path": "test_file_path"
+        },
             "traceability:revision": None,
         },
         "captures": [

--- a/api/tests/test_query_api.py
+++ b/api/tests/test_query_api.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 from database import metadata_repo
 
-from .test_data import valid_metadata_array
+from .test_data import valid_metadata_array, valid_datasourcereference_array
 
 
 def override_metadata_collection():
@@ -32,7 +32,7 @@ async def test_query_meta_success(client):
     )
 
     assert response.status_code == 200
-    assert response.json() == valid_metadata_array
+    assert response.json() == valid_datasourcereference_array
 
     # Reset the dependency overrides after the test
     client.app.dependency_overrides = {}


### PR DESCRIPTION
### What does this PR do?
Changes the query API return value to a 'list of metadata file references'. That is to return the Traceability:Origin fields .I.E. the fields that identify a particular metadata file.
This is an efficiency change opening up the opportunity to more specific processing of returned file entries with more focused API methods returning less metadata. For example, api/datasource/{Account}/{Container}/{Filepath}/Track can be called by an API client to obtain just the track data fields. This is rather than the client obtaining the complete metadata for each file and then locally filtering for the fields required - a process that sees a lot of data being downloaded.


### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [x] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?

