### PR TITLE
Add select plugin option at top of plugins pane

### DIFF
--- a/client/src/pages/recording-view/components/plugins-pane.tsx
+++ b/client/src/pages/recording-view/components/plugins-pane.tsx
@@ -284,6 +284,7 @@ export const PluginsPane = () => {
           value={selectedPlugin}
           onChange={handleChangePlugin}
         >
+          <option value="">Select Plugin</option>
           {plugins &&
             !isError &&
             plugins?.map((plugin, groupIndex) => (


### PR DESCRIPTION
### What does this PR do?
When the page loads the plugins pane should not have a plugin selected, but should tell the user to select a plugin. This PR fixes that.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [x] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc
