### PR TITLE
DRAFT Minimap cleanup and size is now static (300px) to speed up initial page load time

### DIFF
--- a/client/src/api/iqdata/Queries.ts
+++ b/client/src/api/iqdata/Queries.ts
@@ -71,15 +71,15 @@ export function useGetIQData(
 
   const queryClient = useQueryClient();
   const { filesQuery, dataSourcesQuery } = useUserSettings();
-  const [fftsRequired, setFFTsRequired] = useState<number[]>([]);
+  const [minimapFFTIndices, setMinimapFFTIndices] = useState<number[]>([]);
 
   const { data: meta } = useMeta(type, account, container, filePath);
 
   const { data: iqData } = useQuery({
-    queryKey: ['iqData', type, account, container, filePath, fftSize, fftsRequired],
+    queryKey: ['iqData', type, account, container, filePath, fftSize, minimapFFTIndices],
     queryFn: async ({ signal }) => {
       const iqDataClient = IQDataClientFactory(type, filesQuery.data, dataSourcesQuery.data);
-      const iqData = await iqDataClient.getIQDataBlocks(meta, fftsRequired, fftSize, signal);
+      const iqData = await iqDataClient.getIQDataBlocks(meta, minimapFFTIndices, fftSize, signal);
       return iqData;
     },
     enabled: !!meta && !!filesQuery.data && !!dataSourcesQuery.data,
@@ -151,8 +151,8 @@ export function useGetIQData(
   return {
     fftSize,
     currentData,
-    fftsRequired,
-    setFFTsRequired,
+    minimapFFTIndices,
+    setMinimapFFTIndices,
     processedDataUpdated,
   };
 }

--- a/client/src/pages/recording-view/components/scroll-bar.tsx
+++ b/client/src/pages/recording-view/components/scroll-bar.tsx
@@ -66,11 +66,11 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
     // for minimap only. there's so much overhead with blob downloading that this might as well be a high value...
     const skipNFfts = Math.floor(meta.getTotalSamples() / (spectrogramHeight * MINIMAP_FFT_SIZE)); // sets the decimation rate
     const numFfts = Math.floor(meta.getTotalSamples() / MINIMAP_FFT_SIZE / skipNFfts);
-    let dataRange = [];
+    let newMinimapFFTIndices = [];
     for (let i = 0; i < numFfts; i++) {
-      dataRange.push(i * skipNFfts);
+      newMinimapFFTIndices.push(i * skipNFfts);
     }
-    setMinimapFFTIndices(dataRange);
+    setMinimapFFTIndices(newMinimapFFTIndices);
   }, [meta?.getTotalSamples(), spectrogramHeight]);
 
   // filter the displayed iq as we receive new data

--- a/client/src/pages/recording-view/components/scroll-bar.tsx
+++ b/client/src/pages/recording-view/components/scroll-bar.tsx
@@ -64,8 +64,8 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
   // Changes in the spectrogram height require a recalculation of the ffts required
   useEffect(() => {
     // for minimap only. there's so much overhead with blob downloading that this might as well be a high value...
-    const skipNFfts = Math.floor(meta.getTotalSamples() / (spectrogramHeight * MINIMAP_FFT_SIZE)); // sets the decimation rate (manually tweaked)
-    const numFfts = Math.floor(meta.getTotalSamples() / MINIMAP_FFT_SIZE / (skipNFfts + 1));
+    const skipNFfts = Math.floor(meta.getTotalSamples() / (spectrogramHeight * MINIMAP_FFT_SIZE)); // sets the decimation rate
+    const numFfts = Math.floor(meta.getTotalSamples() / MINIMAP_FFT_SIZE / skipNFfts);
     let dataRange = [];
     for (let i = 0; i < numFfts; i++) {
       dataRange.push(i * skipNFfts);

--- a/client/src/pages/recording-view/components/scroll-bar.tsx
+++ b/client/src/pages/recording-view/components/scroll-bar.tsx
@@ -80,9 +80,8 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
     const iqData = new Float32Array(MINIMAP_FFT_SIZE * fftsRequired.length * 2);
     let offset = 0;
     for (let i = 0; i < fftsRequired.length; i++) {
-      const iqDataSlice = currentData[fftsRequired[i]];
-      iqData.set(iqDataSlice, offset);
-      offset += iqDataSlice.length;
+      iqData.set(currentData[fftsRequired[i]], offset);
+      offset += MINIMAP_FFT_SIZE * 2;
     }
     return iqData;
   }, [currentData]);
@@ -101,6 +100,8 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
 
   // Calc scroll handle height and new scaling factor
   useEffect(() => {
+    console.log('========');
+    console.log(fftsRequired);
     if (!meta) return;
     let newHandleHeight =
       (spectrogramHeight / (meta.getTotalSamples() / fftSize / (fftStepSize + 1))) * spectrogramHeight;

--- a/client/src/pages/recording-view/components/scroll-bar.tsx
+++ b/client/src/pages/recording-view/components/scroll-bar.tsx
@@ -100,8 +100,6 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
 
   // Calc scroll handle height and new scaling factor
   useEffect(() => {
-    console.log('========');
-    console.log(minimapFFTIndices);
     if (!meta) return;
     let newHandleHeight =
       (spectrogramHeight / (meta.getTotalSamples() / fftSize / (fftStepSize + 1))) * spectrogramHeight;

--- a/client/src/pages/recording-view/components/scroll-bar.tsx
+++ b/client/src/pages/recording-view/components/scroll-bar.tsx
@@ -112,7 +112,6 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
     if (!ffts) return;
     const rgbData = fftToRGB(ffts, MINIMAP_FFT_SIZE, magnitudeMin, magnitudeMax, colMaps[colmap]);
     let num_final_ffts = ffts.length / MINIMAP_FFT_SIZE;
-    console.log('====', num_final_ffts);
     const newImageData = new ImageData(rgbData, MINIMAP_FFT_SIZE, num_final_ffts);
 
     createImageBitmap(newImageData).then((imageBitmap) => {

--- a/client/src/pages/recording-view/components/scroll-bar.tsx
+++ b/client/src/pages/recording-view/components/scroll-bar.tsx
@@ -32,7 +32,7 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
     setMagnitudeMax,
     windowFunction,
   } = useSpectrogramContext();
-  const { currentData, setFFTsRequired, fftsRequired } = useGetIQData(
+  const { currentData, setMinimapFFTIndices, minimapFFTIndices } = useGetIQData(
     type,
     account,
     container,
@@ -70,17 +70,17 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
     for (let i = 0; i < numFfts; i++) {
       dataRange.push(i * skipNFfts);
     }
-    setFFTsRequired(dataRange);
+    setMinimapFFTIndices(dataRange);
   }, [meta?.getTotalSamples(), spectrogramHeight]);
 
   // filter the displayed iq as we receive new data
   const displayedIQ = useMemo<Float32Array>(() => {
     // join the current ffts
-    if (!currentData || !fftsRequired) return new Float32Array(0);
-    const iqData = new Float32Array(MINIMAP_FFT_SIZE * fftsRequired.length * 2);
+    if (!currentData || !minimapFFTIndices) return new Float32Array(0);
+    const iqData = new Float32Array(MINIMAP_FFT_SIZE * minimapFFTIndices.length * 2);
     let offset = 0;
-    for (let i = 0; i < fftsRequired.length; i++) {
-      iqData.set(currentData[fftsRequired[i]], offset);
+    for (let i = 0; i < minimapFFTIndices.length; i++) {
+      iqData.set(currentData[minimapFFTIndices[i]], offset);
       offset += MINIMAP_FFT_SIZE * 2;
     }
     return iqData;
@@ -101,19 +101,19 @@ const ScrollBar = ({ currentFFT, setCurrentFFT }: ScrollBarProps) => {
   // Calc scroll handle height and new scaling factor
   useEffect(() => {
     console.log('========');
-    console.log(fftsRequired);
+    console.log(minimapFFTIndices);
     if (!meta) return;
     let newHandleHeight =
       (spectrogramHeight / (meta.getTotalSamples() / fftSize / (fftStepSize + 1))) * spectrogramHeight;
     setHandleHeightPixels(Math.max(MINIMUM_SCROLL_HANDLE_HEIGHT_PIXELS, newHandleHeight));
 
-    if (fftsRequired.length > 0) {
+    if (minimapFFTIndices.length > 0) {
       const totalffts = meta.getTotalSamples() / fftSize;
       // get the length ot any of the iqData arrays
       const newScalingFactor = totalffts / spectrogramHeight;
       setScalingFactor(newScalingFactor);
     }
-  }, [spectrogramHeight, fftSize, fftStepSize, meta, fftsRequired]);
+  }, [spectrogramHeight, fftSize, fftStepSize, meta, minimapFFTIndices]);
 
   // Calc the minimap image from ffts to rgb
   useEffect(() => {

--- a/client/src/pages/recording-view/hooks/__tests__/use-spectrogram.test.tsx
+++ b/client/src/pages/recording-view/hooks/__tests__/use-spectrogram.test.tsx
@@ -99,11 +99,11 @@ describe('test metadata fetch and fft calculation', () => {
       wrapper: ({ children }) => createTestWrapper(origin, seed, children),
     });
 
-    await waitFor(() => expect(result.current.fftsRequired.length).toBe(10 + FETCH_PADDING));
+    await waitFor(() => expect(result.current.minimapFFTIndices.length).toBe(10 + FETCH_PADDING));
     const expected = Array(10 + FETCH_PADDING)
       .fill(0)
       .map((_, i) => i);
-    expect(result.current.fftsRequired).toStrictEqual(expected);
+    expect(result.current.minimapFFTIndices).toStrictEqual(expected);
   });
 
   test('should calculate the correct ffts that need to be displayed when decimating', async () => {
@@ -124,21 +124,21 @@ describe('test metadata fetch and fft calculation', () => {
       wrapper: ({ children }) => createTestWrapper(origin, seed, children),
     });
 
-    await waitFor(() => expect(result.current.fftsRequired.length).toBe(10 + FETCH_PADDING));
+    await waitFor(() => expect(result.current.minimapFFTIndices.length).toBe(10 + FETCH_PADDING));
     let expected = Array(10 + FETCH_PADDING)
       .fill(0)
       .map((_, i) => i * 2);
-    expect(result.current.fftsRequired).toStrictEqual(expected);
+    expect(result.current.minimapFFTIndices).toStrictEqual(expected);
 
     act(() => {
       result.current.setFFTStepSize(2);
     });
 
-    await waitFor(() => expect(result.current.fftsRequired.length).toBe(10 + FETCH_PADDING));
+    await waitFor(() => expect(result.current.minimapFFTIndices.length).toBe(10 + FETCH_PADDING));
     expected = Array(10 + FETCH_PADDING)
       .fill(0)
       .map((_, i) => i * 3);
-    expect(result.current.fftsRequired).toStrictEqual(expected);
+    expect(result.current.minimapFFTIndices).toStrictEqual(expected);
   });
 
   test('should calculate the correct ffts that need to be displayed when decimating and changing height', async () => {
@@ -161,19 +161,19 @@ describe('test metadata fetch and fft calculation', () => {
     let expected = Array(10 + FETCH_PADDING)
       .fill(0)
       .map((_, i) => i * 2);
-    await waitFor(() => expect(result.current.fftsRequired.length).toBe(10 + FETCH_PADDING));
-    expect(result.current.fftsRequired).toStrictEqual(expected);
+    await waitFor(() => expect(result.current.minimapFFTIndices.length).toBe(10 + FETCH_PADDING));
+    expect(result.current.minimapFFTIndices).toStrictEqual(expected);
 
     act(() => {
       result.current.setFFTStepSize(2);
       result.current.setSpectrogramHeight(5);
     });
 
-    await waitFor(() => expect(result.current.fftsRequired.length).toBe(5 + FETCH_PADDING));
+    await waitFor(() => expect(result.current.minimapFFTIndices.length).toBe(5 + FETCH_PADDING));
 
     expected = Array(5 + FETCH_PADDING)
       .fill(0)
       .map((_, i) => i * 3);
-    expect(result.current.fftsRequired).toStrictEqual(expected);
+    expect(result.current.minimapFFTIndices).toStrictEqual(expected);
   });
 });

--- a/client/src/pages/recording-view/hooks/use-cursor-context.tsx
+++ b/client/src/pages/recording-view/hooks/use-cursor-context.tsx
@@ -39,7 +39,13 @@ export function CursorContextProvider({ children }) {
   const [cursorTimeEnabled, setCursorTimeEnabled] = useState<boolean>(false);
 
   const { type, account, container, filePath, fftSize } = useSpectrogramContext();
-  const { currentData, setFFTsRequired, fftsRequired } = useGetIQData(type, account, container, filePath, fftSize);
+  const { currentData, setMinimapFFTIndices, minimapFFTIndices } = useGetIQData(
+    type,
+    account,
+    container,
+    filePath,
+    fftSize
+  );
 
   const [cursorData, setCursorData] = useState<Float32Array>(new Float32Array(0));
   const debouseCursorTime = useDebounce(cursorTime, 500);
@@ -62,7 +68,7 @@ export function CursorContextProvider({ children }) {
       offset += fftSize * 2;
     }
     setCursorData(iqData);
-    setFFTsRequired(requiredBlocks);
+    setMinimapFFTIndices(requiredBlocks);
   }, [debouseCursorTime, currentData, fftSize]);
 
   return (

--- a/client/src/pages/recording-view/hooks/use-spectrogram.tsx
+++ b/client/src/pages/recording-view/hooks/use-spectrogram.tsx
@@ -19,7 +19,7 @@ export function useSpectrogram(currentFFT) {
     taps,
     pythonSnippet,
   } = useSpectrogramContext();
-  const { currentData, setFFTsRequired, fftsRequired, processedDataUpdated } = useGetIQData(
+  const { currentData, setMinimapFFTIndices, minimapFFTIndices, processedDataUpdated } = useGetIQData(
     type,
     account,
     container,
@@ -64,13 +64,13 @@ export function useSpectrogram(currentFFT) {
     }
 
     if (!currentData || Object.keys(currentData).length === 0) {
-      setFFTsRequired(requiredBlocks);
+      setMinimapFFTIndices(requiredBlocks);
       return null;
     }
     // check if the blocks are already loaded
     const blocksToLoad = requiredBlocks.filter((block) => !currentData[block]);
-    setFFTsRequired(blocksToLoad);
-    // setFFTsRequired(blocksToLoad);
+    setMinimapFFTIndices(blocksToLoad);
+    // setMinimapFFTIndices(blocksToLoad);
     //if (blocksToLoad.length > 0) {
     //  console.debug('loading blocks', blocksToLoad);
     //}
@@ -101,7 +101,7 @@ export function useSpectrogram(currentFFT) {
     spectrogramHeight,
     displayedIQ,
     currentData,
-    fftsRequired,
+    minimapFFTIndices,
     setFFTStepSize,
     setSpectrogramHeight,
   };

--- a/client/src/pages/recording-view/recording-view.tsx
+++ b/client/src/pages/recording-view/recording-view.tsx
@@ -25,6 +25,7 @@ import { AnnotationViewer } from './components/annotation/annotation-viewer';
 import TimeSelectorMinimap from './components/time-selector-minimap';
 import { useWindowSize } from 'usehooks-ts';
 
+// currentFFT is the index of the FFT at the top of the screen
 export function DisplaySpectrogram({ currentFFT, setCurrentFFT }) {
   const {
     spectrogramWidth,
@@ -58,6 +59,7 @@ export function DisplaySpectrogram({ currentFFT, setCurrentFFT }) {
     colmap,
     windowFunction
   );
+
   function handleWheel(evt: KonvaEventObject<WheelEvent>): void {
     evt.evt.preventDefault();
     const scrollAmount = Math.floor(evt.evt.deltaY);
@@ -74,6 +76,7 @@ export function DisplaySpectrogram({ currentFFT, setCurrentFFT }) {
       setIQData(displayedIQ);
     }
   }, [displayedIQ]);
+
   return (
     <>
       <Stage width={spectrogramWidth + 110} height={30}>

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -6,6 +6,7 @@ export const TILE_SIZE_IN_IQ_SAMPLES = Math.pow(2, 17); // should always be a po
 export const MINIMUM_SCROLL_HANDLE_HEIGHT_PIXELS = 10;
 export const COLORMAP_DEFAULT = 'viridis';
 export const MINIMAP_FFT_SIZE = 64; // determines columns of minimap image
+export const MINIMAP_NUM_FFTs = 300; // determines how many pixels are in the minimap image, higher will make the initial page load slower
 export const FETCH_PADDING = 50; // how many extra ffts we fetch to smooth scrolling this si based on the fft size
 export const MIN_SPECTROGRAM_HEIGHT = 650;
 export const INITIAL_PYTHON_SNIPPET = `import numpy as np

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -5,7 +5,7 @@
 export const TILE_SIZE_IN_IQ_SAMPLES = Math.pow(2, 17); // should always be a power of 2
 export const MINIMUM_SCROLL_HANDLE_HEIGHT_PIXELS = 10;
 export const COLORMAP_DEFAULT = 'viridis';
-export const MINIMAP_FFT_SIZE = 64;
+export const MINIMAP_FFT_SIZE = 64; // determines columns of minimap image
 export const FETCH_PADDING = 50; // how many extra ffts we fetch to smooth scrolling this si based on the fft size
 export const MIN_SPECTROGRAM_HEIGHT = 650;
 export const INITIAL_PYTHON_SNIPPET = `import numpy as np


### PR DESCRIPTION
It's a balance between quality of the minimap and how long it takes the page to load when you go to a new recording, and it was taking quite a while when it required 800-1000 FFTs, now with 300 FFTs it feels way snappier and the minimap still looks pretty good imo.

Also fixed bug where there was 1 extra row at the bottom of zeros

Also changed requiredFFTs to minimapFFTIndices