### PR TITLE
allow for multiple non-IQ output files from plugin

### DIFF
--- a/client/src/pages/recording-view/components/plugins-pane.tsx
+++ b/client/src/pages/recording-view/components/plugins-pane.tsx
@@ -142,6 +142,15 @@ export const PluginsPane = () => {
       }
     }
 
+    const BlobFromSamples = (samples_base64, data_type) => {
+      const samples = window.atob(samples_base64);
+      var blob_array = new Uint8Array(samples.length);
+      for (var i = 0; i < samples.length; i++) {
+        blob_array[i] = samples.charCodeAt(i);
+      }
+      return new Blob([blob_array], { type: data_type });
+    }
+
     fetch(selectedPlugin, {
       method: 'POST',
       headers: {
@@ -224,31 +233,38 @@ export const PluginsPane = () => {
             setModalOpen(true);
           } else {
             // non-IQ Data file
-            const samples_base64 = data.data_output[0]['samples'];
-            const samples = window.atob(samples_base64);
-            var blob_array = new Uint8Array(samples.length);
-            for (var i = 0; i < samples.length; i++) {
-              blob_array[i] = samples.charCodeAt(i);
-            }
-            const a = document.createElement('a');
-            const blob = new Blob([blob_array], { type: data.data_output[0]['data_type'] });
-            const url = window.URL.createObjectURL(blob);
+            let d = new Date();
+            let datestring = d.getFullYear() + "-" + ("0" + (d.getMonth() + 1)).slice(-2) + "-" + ("0" + d.getDate()).slice(-2)
+            datestring += "T" + ("0" + d.getHours()).slice(-2) + ":" + ("0" + d.getMinutes()).slice(-2) + ":" + ("0" + d.getSeconds()).slice(-2);
 
-            a.href = url;
+            for (let j = 0; j < data.data_output.length; j++) {
+              let data_type = data.data_output[j]['data_type'];
 
-            let filename = '';
-            switch (data.data_output[0]['data_type']) {
-              case MimeTypes.audio_wav:
-                filename = 'samples.wav';
-                break;
-            }
-            if (filename != '') {
+              let ext = '';
+              switch (data_type) {
+                case MimeTypes.audio_wav:
+                  ext = 'wav';
+                  break;
+
+                default:
+                  toast.error(`The plugins pane doesn't handle the mime type ${data_type} output by the plugin.`);
+                  break;
+              }
+              if (ext == '') continue;
+
+              let data_output = data.data_output[j]['samples']
+
+              let blob = BlobFromSamples(data_output, data_type)
+
+              let url = window.URL.createObjectURL(blob);
+              let a = document.createElement('a');
+              a.href = url;
+
+              let filename = `sample_${datestring}_${j}.${ext}`;
               a.download = filename;
               a.click();
-            } else {
-              toast.error("The plugins pane doesn't handle the mime type output by the plugin.");
+              window.URL.revokeObjectURL(url);
             }
-            window.URL.revokeObjectURL(url);
           }
         }
 


### PR DESCRIPTION
### What does this PR do?
The new audio detection / speech-to-text plugin returns multiple wav files but only one of them gets downloaded. This PR changes the behavior such that all wav files are downloaded.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [x] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?

