### PR TITLE
Add Edit to DataSource admin page

### DIFF
--- a/client/src/api/Models.ts
+++ b/client/src/api/Models.ts
@@ -9,6 +9,9 @@ export interface DataSource {
   container: string;
   sasToken?: string;
   accountKey?: string;
+  owners?: string[];
+  readers?: string[];
+  public?: boolean;
 }
 
 

--- a/client/src/api/datasource/api-client.ts
+++ b/client/src/api/datasource/api-client.ts
@@ -75,6 +75,17 @@ export class ApiClient implements DataSourceClient {
     }
 
   }
+  async update(dataSource: DataSource): Promise<DataSource> {
+    const response = await this.authUtil.requestWithAuthIfRequired({
+      method: 'put',
+      url: `/api/datasources/${dataSource.account}/${dataSource.container}/datasource`,
+      data: dataSource,
+    });
+    if (response.status !== 204) {
+      throw new Error(`Failed to update datasource: ${response.status}`);
+    }
+    return response.data;
+  }
   async create(dataSource: DataSource): Promise<DataSource> {
     const response = await this.authUtil.requestWithAuthIfRequired({
       method: 'post',

--- a/client/src/api/datasource/blob-client.ts
+++ b/client/src/api/datasource/blob-client.ts
@@ -40,6 +40,10 @@ export class BlobClient implements DataSourceClient {
     return Promise.reject('Not implemented');
   }
 
+  update(dataSource: DataSource): Promise<DataSource> {
+    return Promise.reject('Not implemented');
+  }
+
   features() {
     return {
       updateMeta: false,

--- a/client/src/api/datasource/datasource-client.ts
+++ b/client/src/api/datasource/datasource-client.ts
@@ -7,6 +7,7 @@ export interface DataSourceClient {
   getSasToken(account: string, container: string, filepath: string): Promise<Object>;
   query(queryString: string, signal: AbortSignal): Promise<TraceabilityOrigin[]>;
   create(dataSource: DataSource): Promise<DataSource>;
+  update(dataSource: DataSource): Promise<DataSource>;
   sync(account: string, container: string): Promise<void>;
   features(): { updateMeta: boolean; sync: boolean; query: boolean };
 }

--- a/client/src/api/datasource/local-client.ts
+++ b/client/src/api/datasource/local-client.ts
@@ -52,6 +52,10 @@ export class LocalClient implements DataSourceClient {
     return Promise.reject('Not implemented');
   }
 
+  update(dataSource: DataSource): Promise<DataSource> {
+    return Promise.reject('Not implemented');
+  }
+
   features() {
     return {
       updateMeta: false,

--- a/client/src/pages/admin/pages/add-data-source.tsx
+++ b/client/src/pages/admin/pages/add-data-source.tsx
@@ -1,12 +1,35 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { DataSource } from '@/api/Models';
-import { useAddDataSource } from '@/api/datasource/queries';
+import { useAddDataSource, useUpdateDataSource } from '@/api/datasource/queries';
 import { ClientType } from '@/api/Models';
 import toast from 'react-hot-toast';
 
-export const DataSourceForm = () => {
+interface DataSourceFormProps {
+  initialData?: DataSource;
+  isEditMode?: boolean;
+  setShowModal?: (show: boolean) => void;
+}
+
+export const DataSourceForm = ({ initialData, isEditMode, setShowModal }: DataSourceFormProps) => {
   const addDataSource = useAddDataSource();
+  const updateDataSource = useUpdateDataSource();
   const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    const form = formRef.current;
+    if (initialData && form) {
+      form.name.value = initialData.name || '';
+      form.account.value = initialData.account || '';
+      form.container.value = initialData.container || '';
+      form.description.value = initialData.description || '';
+      form.imageURL.value = initialData.imageURL || '';
+      form.sasToken.value = initialData.sasToken || '';
+      form.accountKey.value = initialData.accountKey || '';
+      form.owners.value = initialData.owners?.join(', ') || '';
+      form.readers.value = initialData.readers?.join(', ') || '';
+      form.public.value = initialData.public ? 'true' : 'false';
+    }
+  }, [initialData]);
 
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
@@ -21,29 +44,53 @@ export const DataSourceForm = () => {
       imageURL: event.target.elements.imageURL.value,
       sasToken: event.target.elements.sasToken.value,
       accountKey: event.target.elements.accountKey.value,
+      owners: event.target.elements.owners.value === '' ? [] : event.target.elements.owners.value.split(',').map(s => s.trim()),
+      readers: event.target.elements.readers.value === '' ? [] : event.target.elements.readers.value.split(',').map(s => s.trim()),
+      public: event.target.elements.public.value.toLowerCase() === 'true' ? true : false,
+
     };
-    addDataSource.mutate(formData, {
-      onSuccess: () => {
-        toast('Successfully added data source', {
-          icon: '👍',
-          className: 'bg-green-100 font-bold',
-        });
-      },
-      onError: (err, newMeta, context) => {
-        if (err.response.status == 409) {
-          toast('You have already added this data source', {
-            icon: '💾',
-            className: 'bg-red-100 font-bold',
+
+    if (isEditMode) {
+      updateDataSource.mutate(formData, {
+        onSuccess: () => {
+          toast('Successfully updated data source', {
+            icon: '👍',
+            className: 'bg-green-100 font-bold',
           });
-        } else {
-          toast('Something went wrong adding the data source', {
+          setShowModal(false);
+        },
+        onError: (err, newMeta, context) => {
+          toast('Something went wrong updating the data source', {
             icon: '😖',
             className: 'bg-red-100 font-bold',
           });
-        }
-        console.error('onError', err);
-      },
-    });
+          console.error('onError', err);
+        },
+      });
+    } else {
+      addDataSource.mutate(formData, {
+        onSuccess: () => {
+          toast('Successfully added data source', {
+            icon: '👍',
+            className: 'bg-green-100 font-bold',
+          });
+        },
+        onError: (err, newMeta, context) => {
+          if (err.response.status == 409) {
+            toast('You have already added this data source', {
+              icon: '💾',
+              className: 'bg-red-100 font-bold',
+            });
+          } else {
+            toast('Something went wrong adding the data source', {
+              icon: '😖',
+              className: 'bg-red-100 font-bold',
+            });
+          }
+          console.error('onError', err);
+        },
+      });
+    }
 
     form.reset();
   };
@@ -62,6 +109,7 @@ export const DataSourceForm = () => {
         name="account"
         placeholder="Storage Account name"
         className="input input-bordered input-success w-full max-w-xs"
+        disabled={isEditMode}
       />
       <br />
       <input
@@ -69,6 +117,7 @@ export const DataSourceForm = () => {
         name="container"
         placeholder="Container Name"
         className="input input-bordered input-success w-full max-w-xs"
+        disabled={isEditMode}
       />
       <br />
       <input
@@ -96,6 +145,24 @@ export const DataSourceForm = () => {
         type="text"
         name="accountKey"
         placeholder="Account Key (optional)"
+        className="input input-bordered input-success w-full max-w-xs"
+      />
+      <input
+        type="text"
+        name="owners"
+        placeholder="Owners (optional)"
+        className="input input-bordered input-success w-full max-w-xs"
+      />
+      <input
+        type="text"
+        name="readers"
+        placeholder="Readers (optional)"
+        className="input input-bordered input-success w-full max-w-xs"
+      />
+      <input
+        type="text"
+        name="public"
+        placeholder="Public access (optional)"
         className="input input-bordered input-success w-full max-w-xs"
       />
       <br />

--- a/client/src/pages/admin/pages/data-sources.tsx
+++ b/client/src/pages/admin/pages/data-sources.tsx
@@ -3,16 +3,18 @@ import { useGetDatasources } from '@/api/datasource/hooks/use-get-datasources';
 import React, { useState } from 'react';
 import { ModalDialog } from '@/features/ui/modal/Modal';
 import DataSourceForm from './add-data-source';
-import { useGetDatasourceFeatures, useSyncDataSource } from '@/api/datasource/queries';
+import { useGetDatasourceFeatures, useSyncDataSource, getDataSource, useGetDataSource } from '@/api/datasource/queries';
 import toast from 'react-hot-toast';
 
 interface DataSourceRowProps {
   dataSource: DataSource;
+  onEdit?: (dataSource: DataSource) => void;
 }
 
-export const DataSourceRow = ({ dataSource }: DataSourceRowProps) => {
+export const DataSourceRow = ({ dataSource, onEdit }: DataSourceRowProps) => {
   const features = useGetDatasourceFeatures(dataSource.type);
   const sync = useSyncDataSource(dataSource.type, dataSource.account, dataSource.container);
+  const edit = useGetDataSource(dataSource.type, dataSource.account, dataSource.container);
   return (
     <div className="card p-2 pb-4 w-80 bg-base-100 shadow-xl border-secondary border-2">
       <figure className="p-2">
@@ -27,6 +29,16 @@ export const DataSourceRow = ({ dataSource }: DataSourceRowProps) => {
       </div>
       {features.sync && (
         <div className="card-actions justify-end">
+          <button
+            aria-label={'edit ' + dataSource.name}
+            className="btn btn-primary"
+            onClick={async (e) => {
+              e.preventDefault();
+              onEdit(await edit());
+            }}
+          >
+            Edit
+          </button>
           <button
             aria-label={'sync ' + dataSource.name}
             className="btn btn-primary"
@@ -50,28 +62,35 @@ export const DataSourceRow = ({ dataSource }: DataSourceRowProps) => {
 export const DataSources = () => {
   const { apiQuery, blobQuery } = useGetDatasources();
   const [showModal, setShowModal] = useState(false);
+  const [dataSourceToEdit, setDataSourceToEdit] = useState<DataSource | null>(null);
+
+  const handleEdit = (dataSource: DataSource) => {
+    const InitDataForEdit = dataSource;
+    setDataSourceToEdit(InitDataForEdit);
+    setShowModal(true);
+  };
 
   return (
     <>
       <h1 className="text-3xl font-bold">Data Sources</h1>
 
-      <button
+      <button className="btn btn-primary"
         aria-label={'Add data source'}
         onClick={() => {
           setShowModal(true);
         }}
       >
-        <h3 className="text-l font-bold ml-2">+ Add data source</h3>
+        + Add data source
       </button>
 
       {showModal && (
-        <ModalDialog heading={'Add data source'} setShowModal={setShowModal}>
-          <DataSourceForm />
+        <ModalDialog heading={dataSourceToEdit ? 'Edit Data Source' : 'Add Data Source'} setShowModal={setShowModal}>
+          <DataSourceForm initialData={dataSourceToEdit} isEditMode={dataSourceToEdit ? true : false} setShowModal={setShowModal} />
         </ModalDialog>
       )}
       <div className="flex flex-wrap gap-4 pt-4 mt-2">
         {apiQuery.data?.map((item, i) => (
-          <DataSourceRow key={i} dataSource={item} />
+          <DataSourceRow key={i} dataSource={item} onEdit={handleEdit} />
         ))}
         {blobQuery.data?.map((item, i) => (
           <DataSourceRow key={i} dataSource={item} />


### PR DESCRIPTION
### What does this PR do?
This PR adds the ability to edit datasource entries via the Admin DataSource page.
It extends the datasource form modal dialog to enable both edits and adds.
It exposes the update api through the client abstractions to enable this.
Next progression will be to enable the selection of security groups for the RBAC permissions of owners and readers.

It also corrects the + Add Data Source button formatting issue :)

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [x] Have you successfully ran tests with your changes locally? Including container validation.
* [ ] Have you lint your code locally prior to submission?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you labelled this PR correctly? E.G. major, milestone, breaking, breaking-change, minor, feature, enhancement, patch, fix, chore, refactor etc

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?

