### PR TITLE
Minor improvements to support Airbus SigMF Files

### DIFF
--- a/client/src/pages/recording-view/components/annotation/annotation-viewer.tsx
+++ b/client/src/pages/recording-view/components/annotation/annotation-viewer.tsx
@@ -99,7 +99,7 @@ const AnnotationViewer = ({ currentFFT }: AnnotationViewerProps) => {
       const start = annotation['core:sample_start'] / fftSize;
       const end = annotation['core:sample_count'] / fftSize + start;
 
-      const visible = start < maximumFFT || end > minimumFFT;
+      const visible = start < maximumFFT && end > minimumFFT;
       const labelVisible = (start > minimumFFT && start < maximumFFT) || (end < maximumFFT && end > minimumFFT);
 
       return {
@@ -289,55 +289,55 @@ const AnnotationViewer = ({ currentFFT }: AnnotationViewerProps) => {
               />
               {/* Label */}
               {annotation.labelVisible && (
-              <>
-              <Html>
-                <div
-                  className={annotation.comment ? 'tooltip tooltip-bottom tooltip-accent absolute' : 'absolute'}
-                  data-tip={annotation.shortComment}
-                  id={index.toString()}
-                  onClick={onAnnotationLabelClick}
-                  style={{
-                    top: annotation.y1 - 23,
-                    left: annotation.x1 * spectrogramWidth,
-                    color: selectedAnnotation == index ? 'pink' : 'black',
-                  }}
-                >
-                  <p
-                    className="font-serif font-bold"
-                    style={{
-                      whiteSpace: 'nowrap',
-                    }}
-                  >
-                    {annotation.label}
-                  </p>
-                </div>
-              </Html>
-              <>
-              {editAnnotationLabelId === index.toString() && (
-                <Html>
-                  <div
-                    className="form-control w-full max-w-xs"
-                    style={{
-                      top: annotation.y1 - 50,
-                      left: annotation.x1 * spectrogramWidth,
-                      position: 'absolute',
-                    }}
-                  >
-                    <label style={{ width: '200px', fontSize: '16px' }}>
-                      <span>Hit Enter to Finish</span>
-                    </label>
-                    <input
-                      type="text"
-                      value={editAnnotationLabelText}
-                      onChange={(e) => setEditAnnotationLabelText(e.target.value)}
-                      onKeyDown={onAnnotationsLabelKeyDown}
-                      style={{ width: '200px', fontSize: '16px', color: 'black' }}
-                    />
-                  </div>
-                </Html>
-              )}
-              </>
-              </>
+                <>
+                  <Html>
+                    <div
+                      className={annotation.comment ? 'tooltip tooltip-bottom tooltip-accent absolute' : 'absolute'}
+                      data-tip={annotation.shortComment}
+                      id={index.toString()}
+                      onClick={onAnnotationLabelClick}
+                      style={{
+                        top: annotation.y1 - 23,
+                        left: annotation.x1 * spectrogramWidth,
+                        color: selectedAnnotation == index ? 'pink' : 'black',
+                      }}
+                    >
+                      <p
+                        className="font-serif font-bold"
+                        style={{
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {annotation.label}
+                      </p>
+                    </div>
+                  </Html>
+                  <>
+                    {editAnnotationLabelId === index.toString() && (
+                      <Html>
+                        <div
+                          className="form-control w-full max-w-xs"
+                          style={{
+                            top: annotation.y1 - 50,
+                            left: annotation.x1 * spectrogramWidth,
+                            position: 'absolute',
+                          }}
+                        >
+                          <label style={{ width: '200px', fontSize: '16px' }}>
+                            <span>Hit Enter to Finish</span>
+                          </label>
+                          <input
+                            type="text"
+                            value={editAnnotationLabelText}
+                            onChange={(e) => setEditAnnotationLabelText(e.target.value)}
+                            onKeyDown={onAnnotationsLabelKeyDown}
+                            style={{ width: '200px', fontSize: '16px', color: 'black' }}
+                          />
+                        </div>
+                      </Html>
+                    )}
+                  </>
+                </>
               )}
             </Fragment>
           )

--- a/client/src/pages/recording-view/components/annotation/annotation-viewer.tsx
+++ b/client/src/pages/recording-view/components/annotation/annotation-viewer.tsx
@@ -101,10 +101,11 @@ const AnnotationViewer = ({ currentFFT }: AnnotationViewerProps) => {
 
       const visible = start < maximumFFT && end > minimumFFT;
       const labelVisible = (start > minimumFFT && start < maximumFFT) || (end < maximumFFT && end > minimumFFT);
+      const capture = meta.getCapture(annotation['core:sample_start']);
 
       return {
-        x1: (annotation['core:freq_lower_edge'] - meta.getCenterFrequency()) / meta.getSampleRate() + 0.5,
-        x2: (annotation['core:freq_upper_edge'] - meta.getCenterFrequency()) / meta.getSampleRate() + 0.5,
+        x1: (annotation['core:freq_lower_edge'] - capture['core:frequency']) / meta.getSampleRate() + 0.5,
+        x2: (annotation['core:freq_upper_edge'] - capture['core:frequency']) / meta.getSampleRate() + 0.5,
         y1: (start - minimumFFT) / (fftStepSize + 1),
         y2: (end - minimumFFT) / (fftStepSize + 1),
         label: annotation.getLabel(),

--- a/client/src/utils/sigmfMetadata.ts
+++ b/client/src/utils/sigmfMetadata.ts
@@ -38,6 +38,16 @@ export class SigMFMetadata {
   dataFileHandle?: FileWithDirectoryAndFileHandle;
   dataClient?: BlobClient;
 
+  getCapture(sampleStart: number): CaptureSegment {
+    let capture = this.captures[0];
+    for (let c of this.captures) {
+      if (c['core:sample_start'] > sampleStart) break;
+
+      capture = c;
+    }
+    return capture;
+  }
+
   getBytesPerIQSample(): number {
     return dataTypeToBytesPerIQSample(this.global['core:datatype']) ?? 2;
   }


### PR DESCRIPTION
This pr introduces 2 changes to properly display Airbus SigMF file:

- only draw visible annotation => sped up drawing for dataset with many annotations
- support to draw annotation relative to capture center frequency
