### PR TITLE
Pass in configuration to fix auth token issue

### DIFF
--- a/client/src/api/datasource/__tests__/ApiClient.test.tsx
+++ b/client/src/api/datasource/__tests__/ApiClient.test.tsx
@@ -23,7 +23,7 @@ describe('ApiClient Metadata Tests', () => {
     ];
     nock('http://localhost:3000').get('/api/datasources').reply(200, data);
 
-    const client = new ApiClient();
+    const client = new ApiClient(null, null, null);
     const result = await client.list();
     expect(result).toEqual(data);
   });
@@ -38,7 +38,7 @@ describe('ApiClient Metadata Tests', () => {
     };
     nock('http://localhost:3000').get('/api/datasources/gnuradio/iqengine/datasource').reply(200, data);
 
-    const client = new ApiClient();
+    const client = new ApiClient(null, null, null);
     const result = await client.get('gnuradio', 'iqengine');
     expect(result).toEqual(data);
   });

--- a/client/src/api/datasource/api-client.ts
+++ b/client/src/api/datasource/api-client.ts
@@ -4,12 +4,13 @@ import { DataSource } from '@/api/Models';
 import { TraceabilityOrigin } from '@/utils/sigmfMetadata';
 import { AccountInfo, IPublicClientApplication } from '@azure/msal-browser';
 import { AuthUtil } from '@/api/utils/Auth-Utils';
+import { AppConfig } from '../config/queries';
 
 export class ApiClient implements DataSourceClient {
   private authUtil: AuthUtil;
 
-  constructor(instance: IPublicClientApplication, account: AccountInfo) {
-    this.authUtil = new AuthUtil(instance, account);
+  constructor(instance: IPublicClientApplication, account: AccountInfo, config: AppConfig) {
+    this.authUtil = new AuthUtil(instance, account, config);
   }
 
   async sync(account: string, container: string): Promise<void> {

--- a/client/src/api/datasource/blob-client.ts
+++ b/client/src/api/datasource/blob-client.ts
@@ -13,7 +13,7 @@ export class BlobClient implements DataSourceClient {
     throw new Error('sync not supported for blob data sources');
   }
 
-  syncAll(account: string, container: string): Promise<void> {
+  syncAll(): Promise<void> {
     throw new Error('sync not supported for blob data sources');
   }
 

--- a/client/src/api/datasource/datasource-client-factory.ts
+++ b/client/src/api/datasource/datasource-client-factory.ts
@@ -5,20 +5,22 @@ import { DataSourceClient } from './datasource-client';
 import { CLIENT_TYPE_API, CLIENT_TYPE_LOCAL, CLIENT_TYPE_BLOB, DataSource } from '@/api/Models';
 import { FileWithDirectoryAndFileHandle } from 'browser-fs-access';
 import { IPublicClientApplication } from '@azure/msal-browser';
+import { AppConfig } from '../config/queries';
 
 export const DataSourceClientFactory = (
   type: string,
   files: FileWithDirectoryAndFileHandle[],
   dataSources: Record<string, DataSource>,
   instance: IPublicClientApplication,
+  config: AppConfig
 ): DataSourceClient => {
   switch (type) {
     case CLIENT_TYPE_API: {
       if (!instance || !instance.getAllAccounts || instance.getAllAccounts().length === 0) {
-        return new ApiClient(null, null);
+        return new ApiClient(null, null, config);
       }
       const accounts = instance.getAllAccounts();
-      return new ApiClient(instance, accounts[0]);
+      return new ApiClient(instance, accounts[0], config);
     }
     case CLIENT_TYPE_LOCAL:
       return new LocalClient(files);

--- a/client/src/api/datasource/hooks/use-get-datasources.tsx
+++ b/client/src/api/datasource/hooks/use-get-datasources.tsx
@@ -4,6 +4,7 @@ import { DataSourceClientFactory } from '@/api/datasource/datasource-client-fact
 import { useQuery } from '@tanstack/react-query';
 import { DataSourceClient } from '@/api/datasource/datasource-client';
 import { useMsal } from '@azure/msal-react';
+import { useConfigQuery } from '@/api/config/queries';
 
 const fetchDataSources = async (client: DataSourceClient) => {
   let response;
@@ -20,9 +21,10 @@ export function useGetDatasources() {
   const { filesQuery, dataSourcesQuery } = useUserSettings();
   const enabled = filesQuery.isSuccess && dataSourcesQuery.isSuccess;
   const { instance } = useMsal();
-  const apiClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance);
-  const localClient = DataSourceClientFactory(ClientType.LOCAL, filesQuery.data, dataSourcesQuery.data, instance);
-  const blobClient = DataSourceClientFactory(ClientType.BLOB, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const apiClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance, data);
+  const localClient = DataSourceClientFactory(ClientType.LOCAL, filesQuery.data, dataSourcesQuery.data, instance, data);
+  const blobClient = DataSourceClientFactory(ClientType.BLOB, filesQuery.data, dataSourcesQuery.data, instance, data);
   const apiQuery = useQuery<DataSource[]>(['datasource', ClientType.API], () => fetchDataSources(apiClient), {
     enabled: enabled,
   });

--- a/client/src/api/datasource/local-client.ts
+++ b/client/src/api/datasource/local-client.ts
@@ -12,7 +12,7 @@ export class LocalClient implements DataSourceClient {
   sync(account: string, container: string): Promise<void> {
     throw new Error('sync not supported for local data sources');
   }
-  syncAll(account: string, container: string): Promise<void> {
+  syncAll(): Promise<void> {
     throw new Error('sync not supported for local data sources');
   }
   query(querystring: string, signal: AbortSignal): Promise<TraceabilityOrigin[]> {

--- a/client/src/api/datasource/queries.ts
+++ b/client/src/api/datasource/queries.ts
@@ -8,6 +8,7 @@ import { useMsal } from '@azure/msal-react';
 import { ClientType } from '@/api/Models';
 import { BlockBlobClient } from '@azure/storage-blob';
 import { FileWithHandle, fileOpen } from 'browser-fs-access';
+import { useConfigQuery } from '../config/queries';
 
 const fetchDataSources = async (client: DataSourceClient) => {
   let response;
@@ -39,7 +40,8 @@ const fetchSasToken = async (
 export const getDataSources = (type: string, enabled = true) => {
   const { filesQuery, dataSourcesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance, data);
   return useQuery(['datasource', type], () => fetchDataSources(client), {
     enabled: enabled,
   });
@@ -48,7 +50,8 @@ export const getDataSources = (type: string, enabled = true) => {
 export const getDataSource = (type: string, account: string, container: string, enabled = true) => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance, data);
   return useQuery(
     ['datasource', type, account, container],
     () => {
@@ -70,7 +73,8 @@ export const useSasToken = (
 ) => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance, data);
 
   return useQuery(
     ['sas', type, account, container, filepath, write],
@@ -86,7 +90,8 @@ export const useSasToken = (
 export const useQueryMeta = (type: string, queryString: string, enabled = true) => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance, data);
   return useQuery<TraceabilityOrigin[]>(
     ['metadata-query', queryString],
     async ({ signal }) => {
@@ -101,14 +106,16 @@ export const useQueryMeta = (type: string, queryString: string, enabled = true) 
 export const useGetDatasourceFeatures = (type: string) => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance, data);
   return client.features();
 };
 
 export const useSyncDataSource = (type: string, account: string, container) => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance, data);
   return () => client.sync(account, container);
 };
 
@@ -116,21 +123,24 @@ export const useSyncDataSource = (type: string, account: string, container) => {
 export const useSyncAllDataSource = () => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory('api', filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory('api', filesQuery.data, dataSourcesQuery.data, instance, data);
   return () => client.syncAll();
 };
 
 export const useGetDataSource = (type: string, account: string, container: string) => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const client = DataSourceClientFactory(type, filesQuery.data, dataSourcesQuery.data, instance, data);
   return () => client.get(account, container);
 };
 
 export const useAddDataSource = () => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const dataSourceClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const dataSourceClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance, data);
 
   return useMutation({
     mutationFn: (dataSource: DataSource) => {
@@ -146,7 +156,8 @@ export const useAddDataSource = () => {
 export const useUpdateDataSource = () => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const dataSourceClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const dataSourceClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance, data);
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -166,7 +177,8 @@ export const useUpdateDataSource = () => {
 export const useUploadDataSource = (type: string, account: string, container: string, setProgress) => {
   const { dataSourcesQuery, filesQuery } = useUserSettings();
   const { instance } = useMsal();
-  const dataSourceClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance);
+  const { data } = useConfigQuery();
+  const dataSourceClient = DataSourceClientFactory(ClientType.API, filesQuery.data, dataSourcesQuery.data, instance, data);
 
   async function uploadBlob(f: FileWithHandle, account, container) {
     // Create azure blob client

--- a/client/src/api/iqdata/ApiClient.ts
+++ b/client/src/api/iqdata/ApiClient.ts
@@ -5,12 +5,13 @@ import { IQDataSlice } from '@/api/Models';
 import { convertToFloat32 } from '@/utils/fetch-more-data-source';
 import { AccountInfo, IPublicClientApplication } from '@azure/msal-browser';
 import { AuthUtil } from '@/api/utils/Auth-Utils';
+import { AppConfig } from '../config/queries';
 
 export class ApiClient implements IQDataClient {
   private authUtil: AuthUtil;
 
-  constructor(instance: IPublicClientApplication, account: AccountInfo) {
-    this.authUtil = new AuthUtil(instance, account);
+  constructor(instance: IPublicClientApplication, account: AccountInfo, config: AppConfig) {
+    this.authUtil = new AuthUtil(instance, account, config);
   }
   async getIQDataBlocks(
     meta: SigMFMetadata,

--- a/client/src/api/utils/Auth-Utils.ts
+++ b/client/src/api/utils/Auth-Utils.ts
@@ -1,18 +1,20 @@
 import { AccountInfo, IPublicClientApplication } from "@azure/msal-browser";
 import axios, { AxiosRequestConfig, CancelToken } from "axios";
-import { C } from "vitest/dist/types-3c7dbfa5";
+import { AppConfig } from '@/api/config/queries';
 
 export class AuthUtil {
     private instance: IPublicClientApplication;
     private account: AccountInfo;
-
-    constructor(instance: IPublicClientApplication, account: AccountInfo) {
+    private config: AppConfig;
+    
+    constructor(instance: IPublicClientApplication, account: AccountInfo, config: AppConfig) {
       this.instance = instance;
       this.account = account;
+      this.config = config;
     }
 
     async getAccessToken() {
-      const api_scope = 'api://' + import.meta.env.IQENGINE_APP_ID + '/api';
+      const api_scope = 'api://' + this.config?.appId + '/api';
       if (!this.account) return null;
       try {
         const response = await this.instance.acquireTokenSilent({


### PR DESCRIPTION
There was an issue when react was built without the client id added until runtime.

This was causing the following bug when trying to get a token to get user information or data source information from the API, because the token was failing to generate and thus you can only get public data sources:
<img width="207" alt="image" src="https://github.com/IQEngine/IQEngine/assets/9397730/c4e4ed40-5916-4c41-9215-5a61cacca526">

Passing through the configuration as detailed in these changes means that this will get the client id at runtime and successfully acquire the token.