### PR TITLE
Remove admin undefined access

### DIFF
--- a/client/src/pages/admin/__tests__/admin-undefined.test.tsx
+++ b/client/src/pages/admin/__tests__/admin-undefined.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { AllProviders } from '@/mocks/setup-tests';
 import { MemoryRouter } from 'react-router-dom';
 
-describe('Test Admin Unauthorised', () => {
+describe('Test Admin Undefined', () => {
   beforeEach(() => {
     vi.mock('@azure/msal-react', async () => {
       return {
@@ -16,7 +16,6 @@ describe('Test Admin Unauthorised', () => {
               getActiveAccount: () => {
                 return {
                   idTokenClaims: {
-                    roles: ['IQEngine-User'],
                   },
                 };
               },

--- a/client/src/pages/admin/__tests__/admin.test.tsx
+++ b/client/src/pages/admin/__tests__/admin.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import Admin from '@/pages/admin/admin';
 import '@testing-library/jest-dom';

--- a/client/src/pages/admin/admin.tsx
+++ b/client/src/pages/admin/admin.tsx
@@ -32,7 +32,7 @@ export const Admin = () => {
   if (
     activeAccount === null ||
     activeAccount === undefined ||
-    activeAccount?.idTokenClaims?.roles?.includes('IQEngine-Admin') === false
+    activeAccount?.idTokenClaims?.roles?.includes('IQEngine-Admin') !== true 
   ) {
     return (
       <>


### PR DESCRIPTION
When no roles were defined for the user, they were still able to view the admin pages, this now correctly says they are undefined if they don't have the appropriate role.