### PR TITLE
Async to Sync plugin proxy

### DIFF
--- a/plugins/src/plugins/sync_proxy/sync_proxy.py
+++ b/plugins/src/plugins/sync_proxy/sync_proxy.py
@@ -1,0 +1,65 @@
+import json
+import base64
+import cv2
+import io
+import numpy as np
+from models.models import MetadataFile, Output
+from models.plugin import Plugin
+import os
+import urllib.request
+import requests
+
+proxy_url = os.environ.get('IQENGINE_PROXY_URL', 'http://127.0.0.1:9000/plugins/userdef')
+
+class sync_proxy(Plugin):
+    sample_rate: int = 0
+    center_freq: int = 0
+
+    def get_definition(self):
+        with urllib.request.urlopen(proxy_url) as response:
+            definition = response.read()
+            definition = json.loads(definition)
+            # Add proxy_url
+            definition['proxy_url'] = {
+                'title': 'The url of the async url',
+                'type': 'string',
+                'default': proxy_url
+            }
+            return definition
+
+    def set_custom_params(self, custom_params: dict):
+        self.custom_params = custom_params
+
+    def rf_function(self, samples, job_context=None):
+        job_id = job_context.job_id
+
+        samples = samples.tobytes()
+        samples = base64.b64encode(samples)
+        samples = samples.decode('ascii')
+        data = {
+            'custom_params': self.custom_params,
+            'samples_b64': [{
+                'samples': samples,
+                'data_type': 'iq/cf32_le',
+                'sample_rate': self.sample_rate
+            }]
+        }
+        print(data)
+        proxy_url = self.custom_params['proxy_url']
+        r = requests.post(url=proxy_url, json=data)
+        r = r.json()
+        print(r)
+        details = r.get('details', None)
+        if details is not None:
+            self.set_status(job_id, 100, str(details))
+            return Output()
+        else:
+            samples_b64 = r['data_output'][0]['samples']
+            metadata = MetadataFile(
+                file_name=job_context.file_name or 'iqfile',
+                data_type="iq/cf32_le",
+                sample_rate=self.sample_rate,
+                center_freq=self.center_freq,
+            )
+
+            return Output(metadata_file=metadata, output_data=samples_b64)


### PR DESCRIPTION
While IQEngine is transitioning from Sync plugins to Async one, this pull-request propose a plugin that bridge the gap for existing plugin. It has been tested with my current sync plugin in rust as of 2024-05-29.

This plugin can proxy only function at a time. The url of the proxied sync plugin is configured by the environment variable `IQENGINE_PROXY_URL`.

For instance, if your `userdef` sync function plugin is served on port 9000, one can launch the following command:
`IQENGINE_PROXY_URL=http://127.0.0.1:9000/plugins/userdef uvicorn --host 0.0.0.0 --port 8000 plugins_ap`
