### PR TITLE
Bugfix: Fix diffSeconds calculation for time cursor

### DIFF
--- a/client/src/pages/recording-view/components/time-selector.tsx
+++ b/client/src/pages/recording-view/components/time-selector.tsx
@@ -26,7 +26,7 @@ const TimeSelector = ({ currentFFT }: TimeSelectorProps) => {
   // update diff
   useEffect(() => {
     if (!cursorTimeEnabled || !meta) return;
-    const diffSeconds = cursorTime.end - cursorTime.start / meta.getSampleRate();
+    const diffSeconds = (cursorTime.end - cursorTime.start) / meta.getSampleRate();
     const formatted = unitPrefixSamples(cursorTime.end - cursorTime.start);
     setDiffSamples('Δ ' + formatted.samples + formatted.unit + ' samples');
     const formattedSeconds = unitPrefixSeconds(diffSeconds);


### PR DESCRIPTION
- Divide cursorTime difference (end - start) by sample rate
