### PR TITLE
Update converter.tsx to fix the link to the converter README.md in main instead of "speed-up-wav-converter".

### DIFF
--- a/client/src/pages/converter/converter.tsx
+++ b/client/src/pages/converter/converter.tsx
@@ -18,7 +18,7 @@ export const Converter = () => {
               <br />
               <br />
               If you would like to run the converter straight from Python locally, see{' '}
-              <a href="https://github.com/IQEngine/IQEngine/blob/speed-up-wav-converter/api/converters/README.md">
+              <a href="https://github.com/IQEngine/IQEngine/blob/main/api/converters/README.md">
                 these steps
               </a>
               .


### PR DESCRIPTION
This PR is to fix the link to the converter README.md, by pointing to main, instead of "speed-up-wav-converter". Not sure on the history here, so there may be a better readme to link to, but the one in main makes sense to me.